### PR TITLE
Обновление информации по .NET контейнерам

### DIFF
--- a/Containers/.NET3.1/fuzz/CoreFX/Dockerfile
+++ b/Containers/.NET3.1/fuzz/CoreFX/Dockerfile
@@ -3,9 +3,10 @@ FROM ubuntu:18.04 AS base_image
 WORKDIR /build
 
 RUN apt update && \
-    apt-get -y install libunwind8 libicu60 curl git clang-3.9 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev locales gcc wget apt-transport-https
+    apt-get -y install libunwind8 libicu60 curl git clang-3.9 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev locales gcc wget apt-transport-https \
+    build-essential python3-dev automake git flex bison libglib2.0-dev libpixman-1-dev python3-setuptools lld llvm llvm-dev clang
 
-RUN apt-get download libssl1.0-dev
+RUN apt-get -y install gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-dev
 
 RUN locale-gen en_US.UTF-8
 
@@ -14,9 +15,9 @@ RUN cd corefx && \
     ./build.sh -allconfigurations --configuration release
 
 WORKDIR /afl
-RUN wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz && \
-    tar -xvf afl-latest.tgz && \
-    cd afl-2.52b && \
+RUN wget https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/3.14c.tar.gz && \
+    tar -xvf 3.14c.tar.gz && \
+    cd AFLplusplus-3.14c && \
     make
 
 WORKDIR /app
@@ -48,4 +49,4 @@ ARG FUZZ_TARGET_LIBRARY
 
 RUN sharpfuzz out/${FUZZ_TARGET_LIBRARY}
 
-CMD if [ -f "samples.dict" ]; then /afl/afl-2.52b/afl-fuzz -i Testcases -o findings -t 5000 -m 10000 -x samples.dict ./out/CoreFX; else /afl/afl-2.52b/afl-fuzz -i Testcases -o findings -t 5000 -m 10000 ./out/CoreFX; fi
+CMD if [ -f "samples.dict" ]; then /afl/AFLplusplus-3.14c/afl-fuzz -i Testcases -o findings -t 5000 -m 10000 -x samples.dict ./out/CoreFX; else /afl/AFLplusplus-3.14c/afl-fuzz -i Testcases -o findings -t 5000 -m 10000 ./out/CoreFX; fi

--- a/Containers/.NET3.1/fuzz/CoreFX/Dockerfile
+++ b/Containers/.NET3.1/fuzz/CoreFX/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /build
 RUN apt update && \
     apt-get -y install libunwind8 libicu60 curl git clang-3.9 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev locales gcc wget apt-transport-https
 
-RUN apt-get download libssl1.0-dev && \
-    dpkg-deb -X libssl1.0-dev_1.0.2n-1ubuntu5.6_amd64.deb /
+RUN apt-get download libssl1.0-dev
 
 RUN locale-gen en_US.UTF-8
 

--- a/Containers/.NET5/README.md
+++ b/Containers/.NET5/README.md
@@ -11,12 +11,18 @@
 
 Устанавливается компилятор clang-12, выполняется сборка AFLplusplus (протестировано на 3.12c), подменяются компиляторы для сборки собственно coreclr на -lto -компиляторы из состава AFL++, выполняется сборка coreclr с формированием слования лексем на этапе компиляции (AUTODICTIONARY из состава последнийх AFL++ - для самопроверки, что всё работает)
 
-*docker build --build-arg cuid=$(id -u) --build-arg cgid=$(id -g) --build-arg cuidname=$(id -un) --build-arg cgidname=$(id -gn) -t net5_coreclr -f Dockerfile_net5_coreclr.txt .*
+``` bash
+docker build --build-arg cuid=$(id -u) --build-arg cgid=$(id -g) --build-arg cuidname=$(id -un) --build-arg cgidname=$(id -gn) -t net5_coreclr -f Dockerfile_net5_coreclr.txt .
+```
 
 # Команда запуска контейнера
 
-*docker run -it --name=net5 net5_coreclr*
+``` bash
+docker run -it --name=net5 net5_coreclr
+```
 
 # Команда тестового запуска фаззинга инструментированного бинарника дизассемблера (всё должно завестить, будут находится разумные сэмплы (MZ в начале))
 
- *mkdir -p test/in && echo 111 > test/in/sam && ../AFLplusplus/afl-fuzz -i test/in -o out -x clr.dict -- artifacts/bin/coreclr/Linux.x64.Debug/ildasm @@*
+``` bash
+mkdir -p test/in && echo 111 > test/in/sam && ../AFLplusplus/afl-fuzz -i test/in -o out -x clr.dict -- artifacts/bin/coreclr/Linux.x64.Debug/ildasm @@
+```


### PR DESCRIPTION
При сборке контейнера для .NET 3.1 постоянно выскакивает ошибка что файл dpkg-deb -X libssl1.0-dev_1.0.2n-1ubuntu5.6_amd64.deb отсутствует (тк он не был скачен)
Установки через apt достаточно 

Также тестировал сборку докер контейнера для .NET 5, в файле README.md не совсем корректное выделение команд т.к в таком случае гитхаб не позволяет скопировать строчку, подправил по аналогии с .NET 3.1
Сборка не удалась #20 

Также на самом деле хотелось бы переименовать "Dockerfile_net5_coreclr.txt" в "Dockerfile" (чтобы различные IDE автоматически подсвечивали синтаксис)

UPD: увидел issue #18, обновил версию AFL++, у себя тестировал, всё должно быть ок